### PR TITLE
import module change for django 1.6

### DIFF
--- a/django_summernote/urls.py
+++ b/django_summernote/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django_summernote.views import editor, upload_attachment
 
 urlpatterns = patterns(


### PR DESCRIPTION
ImportError: No module named defaults

django.conf.urls.defaults is deprecated use django.conf.urls instead
