### PR TITLE
problem when I using Amazon S3

### DIFF
--- a/django_summernote/templates/django_summernote/upload_attachment.json
+++ b/django_summernote/templates/django_summernote/upload_attachment.json
@@ -3,7 +3,7 @@
     {
         "name": "{{ attachment.name }}",
         "size": {{ attachment.file.size }},
-        "url": "{{ attachment.file.url }}"
+        "url": "{{ attachment.file.url|safe }}"
     }
     {% if not forloop.last %},{% endif %}
 {% endfor %}


### PR DESCRIPTION
when I use Amazon S3, the file url can contain special char '&'.
and django template rendered it to '&amp;'.

so I suggest this change for solve problem.
