### PR TITLE
Expose summernote styleWithSpan

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ In settings.py,
         # Using Summernote Air-mode
         'airMode': False,
 
+        # Use native HTML tags (`<b>`, `<i>`, ...) instead of style attributes
+        # (Firefox, Chrome only)
+        'styleWithTags': True,
+
         # Change editor size
         'width': '100%',
         'height': '480',

--- a/django_summernote/settings.py
+++ b/django_summernote/settings.py
@@ -15,6 +15,7 @@ SETTINGS_USER = getattr(settings, 'SUMMERNOTE_CONFIG', {})
 SETTINGS_DEFAULT = {
     'iframe': True,
     'airMode': False,
+    'styleWithSpan': True,
     'empty': ('<p><br/></p>', '<p><br></p>'),
 
     'width': 720,

--- a/django_summernote/templates/django_summernote/widget_iframe_editor.html
+++ b/django_summernote/templates/django_summernote/widget_iframe_editor.html
@@ -43,6 +43,7 @@
     $('#summernote').summernote({
         height: settings.height,
         airMode: settings.airMode == 'true',
+        styleWithSpan: {{ styleWithSpan }},
         toolbar: settings.toolbar,
         lang: settings.lang,
         oninit: function() {

--- a/django_summernote/templates/django_summernote/widget_inplace.html
+++ b/django_summernote/templates/django_summernote/widget_inplace.html
@@ -12,6 +12,7 @@ $({{ id }}_textarea).hide();
 $({{ id }}_src).summernote({
     height: {{ height }},
     airMode: {{ airMode }},
+    styleWithSpan: {{ styleWithSpan }},
     toolbar: {{ toolbar|safe }},
     lang: '{{ lang }}',
     onblur: function() {

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -31,6 +31,8 @@ class SummernoteWidgetBase(forms.Textarea):
             'toolbar': summernote_config['toolbar'],
             'lang': _get_proper_language(),
             'airMode': 'true' if summernote_config['airMode'] else 'false',
+            'styleWithSpan': ('true' if summernote_config['styleWithSpan']
+                              else 'false'),
             'height': summernote_config['height'],
             'url': {
                 'upload_attachment':


### PR DESCRIPTION
Summernote has an option which makes summernote using native HTML tags
instead of using style attributes (see HackerWins/summernote#114).

According to a comment in the summernote code [0], this is only working
in Firefox and Chrome. I haven't checked that.

By default the option is True, which doesn't change default behavior.

[0]
https://github.com/HackerWins/summernote/blob/master/src/js/settings.js
