### PR TITLE
Run a html whitelist scrubber before saving to the database. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ In settings.py,
 
         # Set external media files for SummernoteInplaceWidget.
         # !!! Be sure to put {{ form.media }} in template before initiate summernote.
-        'inplacewidget_external_css': (                                             
-            '//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css',      
+        'inplacewidget_external_css': (
+            '//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css',
             '//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css',
-        ),                                                                          
-        'inplacewidget_external_js': (                                              
-            '//code.jquery.com/jquery-1.9.1.min.js',                                
-            '//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js',        
+        ),
+        'inplacewidget_external_js': (
+            '//code.jquery.com/jquery-1.9.1.min.js',
+            '//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js',
         ),
     }
 
@@ -145,6 +145,20 @@ Or, you can styling editor via attributes of the widget. These adhoc styling wil
 (TODO) Document for addtional settings will be added, soon. :^D
 
 
+HTML WHITELIST SCRUBBING
+------------------------
+
+[Scrubber](https://github.com/samuel/python-scrubber/tree/master) is a
+white-listing HTML sanitizer. It uses BeautifulSoup to parse an HTML
+document and removes any tags and attributes that are not specifically
+allowed.
+
+To enable [Scrubber](https://github.com/samuel/python-scrubber/tree/master),
+simply install the library:
+
+    pip install scrubber
+
+
 AUTHOR
 ------
 
@@ -156,6 +170,7 @@ THANKS TO
 
   - [jaeyoung](https://github.com/jeyraof) : Debugging on Django 1.4
   - [kroisse](https://github.com/kroisse) : Fixing problem on importing module
+
 
 LICENSE
 -------

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -1,5 +1,8 @@
 import json
 import os
+
+from scrubber import Scrubber
+
 from django import forms
 from django.core.urlresolvers import reverse
 from django.template import Context
@@ -53,10 +56,10 @@ class SummernoteWidget(SummernoteWidgetBase):
     def render(self, name, value, attrs=None):
         attrs_for_textarea = attrs.copy()
         attrs_for_textarea['hidden'] = 'true'
+        value = Scrubber(autolink=False).scrub(value)
         html = super(SummernoteWidget, self).render(name,
                                                     value,
                                                     attrs_for_textarea)
-
         final_attrs = self.build_attrs(attrs)
         del final_attrs['id']  # Use original attributes without id.
 
@@ -94,6 +97,7 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
         attrs_for_textarea = attrs.copy()
         attrs_for_textarea['hidden'] = 'true'
         attrs_for_textarea['id'] += '-textarea'
+        value = Scrubber(autolink=False).scrub(value)
         html = super(SummernoteInplaceWidget, self).render(name,
                                                            value,
                                                            attrs_for_textarea)

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -1,7 +1,10 @@
 import json
 import os
 
-from scrubber import Scrubber
+try:
+    import scrubber
+except ImportError:
+    scrubber = None
 
 from django import forms
 from django.core.urlresolvers import reverse
@@ -56,7 +59,8 @@ class SummernoteWidget(SummernoteWidgetBase):
     def render(self, name, value, attrs=None):
         attrs_for_textarea = attrs.copy()
         attrs_for_textarea['hidden'] = 'true'
-        value = Scrubber(autolink=False).scrub(value)
+        if scrubber:
+            value = scrubber.Scrubber(autolink=False).scrub(value)
         html = super(SummernoteWidget, self).render(name,
                                                     value,
                                                     attrs_for_textarea)
@@ -97,7 +101,8 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
         attrs_for_textarea = attrs.copy()
         attrs_for_textarea['hidden'] = 'true'
         attrs_for_textarea['id'] += '-textarea'
-        value = Scrubber(autolink=False).scrub(value)
+        if scrubber:
+            value = scrubber.Scrubber(autolink=False).scrub(value)
         html = super(SummernoteInplaceWidget, self).render(name,
                                                            value,
                                                            attrs_for_textarea)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     description='Summernote plugin for Django',
     classifiers=CLASSIFIERS,
 
-    install_requires=['django'],
+    install_requires=['django', ],
     test_suite='runtests.runtests',
     tests_require=['django-dummy-plug', ],
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     description='Summernote plugin for Django',
     classifiers=CLASSIFIERS,
 
-    install_requires=['django', 'scrubber'],
+    install_requires=['django'],
     test_suite='runtests.runtests',
     tests_require=['django-dummy-plug', ],
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     description='Summernote plugin for Django',
     classifiers=CLASSIFIERS,
 
-    install_requires=['django', ],
+    install_requires=['django', 'scrubber'],
     test_suite='runtests.runtests',
     tests_require=['django-dummy-plug', ],
 )


### PR DESCRIPTION
We could make this an optional dependency, but it is safer and seems simple enough to be a default. Thoughts?

See: http://samuelks.com/python-scrubber/docs/