### PR TITLE
Fix django-pipeline incompatibility

### DIFF
--- a/django_summernote/templates/django_summernote/widget_iframe_editor.html
+++ b/django_summernote/templates/django_summernote/widget_iframe_editor.html
@@ -36,7 +36,7 @@
         // include summernote language pack, synchronously
         if( settings.lang != 'en-US' ) {
             $.ajaxSetup({async:false});
-            $.getScript('{% static "django_summernote/lang/summernote-" %}' + settings.lang + '.js');
+            $.getScript('{{ STATIC_URL }}django_summernote/lang/summernote-' + settings.lang + '.js');
             $.ajaxSetup({async:true});
         }
 

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -72,6 +72,7 @@ class SummernoteWidget(SummernoteWidgetBase):
                 'width': summernote_config['width'],
                 'height': summernote_config['height'],
                 'settings': json.dumps(self.template_contexts()),
+                'STATIC_URL': settings.STATIC_URL,
             }
         )
         return mark_safe(html)


### PR DESCRIPTION
We can't use partial filenames in the {% static %} tag when using
django-pipeline, as it immediately tries to source the file on disk
and throws an error when it can't be found.
Instead, pass the STATIC_URL setting through to the template and use this.

This is a partial revert of 2b35e7b2a302c8396177d3f44cb998d2b8d715de.
