### PR TITLE
Fix label covering issue

### DIFF
--- a/django_summernote/static/django_summernote/django_summernote.css
+++ b/django_summernote/static/django_summernote/django_summernote.css
@@ -1,3 +1,7 @@
 html, body {
-    margin: 0
+    margin: 0;
+}
+
+.note-editor {
+    display: inline-block;
 }

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -82,6 +82,7 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
     class Media:
         css = {'all': (summernote_config['inplacewidget_external_css']) + (
             _static_url('django_summernote/summernote.css'),
+            _static_url('django_summernote/django-summernote.css'),
         )}
 
         js = (summernote_config['inplacewidget_external_js']) + (


### PR DESCRIPTION
I just found simple solution of Issue #68 

add `display: inline-block;` code in note-editor class.

I used django-summernote.css file and added it to widgets.py file.

Following is fixed screenshot.

![label-covered_fixed](https://cloud.githubusercontent.com/assets/3654082/4946501/08e44f44-6615-11e4-9cd6-7d111f82c6bc.png)

I hope it helps.
