### PR TITLE
Fix reference to django_summernote.css

### DIFF
--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -82,7 +82,7 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
     class Media:
         css = {'all': (summernote_config['inplacewidget_external_css']) + (
             _static_url('django_summernote/summernote.css'),
-            _static_url('django_summernote/django-summernote.css'),
+            _static_url('django_summernote/django_summernote.css'),
         )}
 
         js = (summernote_config['inplacewidget_external_js']) + (


### PR DESCRIPTION
The in place widget references `django_summernote/django-summernote.css`, which doesn't exist -- the filename uses an underscore, not a dash.
