### PR TITLE
Corregido el nombre del objeto al usar FK

### DIFF
--- a/django_summernote/models.py
+++ b/django_summernote/models.py
@@ -49,3 +49,6 @@ class Attachment(models.Model):
         storage=_get_attachment_storage()
     )
     uploaded = models.DateTimeField(auto_now_add=True)
+
+    def __unicode__(self):
+        return u"%s" % (self.name)


### PR DESCRIPTION
Cuando se deseaba reutilizar un adjunto dentro del admin, con relaciones foraneas, no era posible ver el nombre del archivo porque dicho objeto no estaba configurado para ello.