### PR TITLE
Allow the configuration of the colors palettes in settings.py

### DIFF
--- a/django_summernote/settings.py
+++ b/django_summernote/settings.py
@@ -69,6 +69,17 @@ SETTINGS_DEFAULT = {
         'zh': 'zh-CN',
     },
 
+    'colors': [
+        ['#000000', '#424242', '#636363', '#9C9C94', '#CEC6CE', '#EFEFEF', '#F7F7F7', '#FFFFFF'],
+        ['#FF0000', '#FF9C00', '#FFFF00', '#00FF00', '#00FFFF', '#0000FF', '#9C00FF', '#FF00FF'],
+        ['#F7C6CE', '#FFE7CE', '#FFEFC6', '#D6EFD6', '#CEDEE7', '#CEE7F7', '#D6D6E7', '#E7D6DE'],
+        ['#E79C9C', '#FFC69C', '#FFE79C', '#B5D6A5', '#A5C6CE', '#9CC6EF', '#B5A5D6', '#D6A5BD'],
+        ['#E76363', '#F7AD6B', '#FFD663', '#94BD7B', '#73A5AD', '#6BADDE', '#8C7BC6', '#C67BA5'],
+        ['#CE0000', '#E79439', '#EFC631', '#6BA54A', '#4A7B8C', '#3984C6', '#634AA5', '#A54A7B'],
+        ['#9C0000', '#B56308', '#BD9400', '#397B21', '#104A5A', '#085294', '#311873', '#731842'],
+        ['#630000', '#7B3900', '#846300', '#295218', '#083139', '#003163', '#21104A', '#4A1031']
+      ],
+
     'attachment_upload_to': uploaded_filepath,
     'attachment_storage_class': None,
     'attachment_filesize_limit': 1024 * 1024,

--- a/django_summernote/templates/django_summernote/widget_iframe_editor.html
+++ b/django_summernote/templates/django_summernote/widget_iframe_editor.html
@@ -51,6 +51,7 @@
             styleWithSpan: settings.styleWithSpan == 'true',
             direction: settings.direction,
             toolbar: settings.toolbar,
+            colors: settings.colors,
             lang: settings.lang,
             oninit: function() {
                 var nEditor = $('.note-editor');

--- a/django_summernote/templates/django_summernote/widget_inplace.html
+++ b/django_summernote/templates/django_summernote/widget_inplace.html
@@ -23,6 +23,7 @@ $(function() {
         styleWithSpan: {{ id }}_settings.styleWithSpan == 'true',
         direction: {{ id }}_settings.direction,
         toolbar: {{ id }}_settings.toolbar,
+        colors: {{ id }}_settings.colors,
         lang: {{ id }}_settings.lang,
         onblur: function() {
             {{ id }}_textarea.value = $(this).code();

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -29,6 +29,7 @@ class SummernoteWidgetBase(forms.Textarea):
     def template_contexts(self):
         return {
             'toolbar': summernote_config['toolbar'],
+            'colors': summernote_config['colors'],
             'lang': _get_proper_language(),
             'airMode': summernote_config['airMode'],
             'styleWithSpan': summernote_config['styleWithSpan'],


### PR DESCRIPTION
I'm not sure it's the right way to do it nor if it works in every use cases. I only tested this patch in the admin interface.