### PR TITLE
Removed deprecated patterns syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ SETUP
 
 3. Add `django_summernote.urls` to `urls.py`.
 
-        urlpatterns = patterns('',
+        urlpatterns = [
             ...
-            (r'^summernote/', include('django_summernote.urls')),
+            url(r'^summernote/', include('django_summernote.urls')),
             ...
-        )
+        ]
 
 4. Run `syncdb` for preparing attachment model.
 

--- a/django_summernote/urls.py
+++ b/django_summernote/urls.py
@@ -1,10 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django_summernote.views import editor, upload_attachment
 
-urlpatterns = patterns(
-    'django_summernote.views',
+urlpatterns = [
     url(r'^editor/(?P<id>.+)/$', editor,
         name='django_summernote-editor'),
     url(r'^upload_attachment/$', upload_attachment,
         name='django_summernote-upload_attachment'),
-)
+]


### PR DESCRIPTION
Django 1.10 won't support the deprecated django.conf.urls.patterns.