### PR TITLE
Introducing Custom Attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ In settings.py,
         # Set custom storage class for attachments.
         'attachment_storage_class': 'my.custom.storage.class.name',
 
+        # Set custom model for attachments.
+        'attachment_model': 'django_summernote.Attachment',
+
         # Set external media files for SummernoteInplaceWidget.
         # !!! Be sure to put {{ form.media }} in template before initiate summernote.
         'inplacewidget_external_css': (                                             
@@ -142,9 +145,15 @@ In settings.py,
 
 Or, you can styling editor via attributes of the widget. These adhoc styling will override settings from `SUMMERNOTE_CONFIG`.
 
-    # Apply adhoc style via attibutes
+    # Apply adhoc style via attributes
     class SomeForm(forms.Form):
         foo = forms.CharField(widget=SummernoteWidget(attrs={'width': '50%', 'height': '400px'}))
+
+You can also pass additional parameters to custom `Attachment` model by adding attributes to SummernoteWidget or SummernoteInplaceWidget, any attribute starting with `data-` will be pass to the `save(...)` method of custom `Attachment` model as `**kwargs`.
+
+    # Pass additional parameters to Attachment via attributes
+    class SomeForm(forms.Form):
+        foo = forms.CharField(widget=SummernoteWidget(attrs={'data-user-id': 123456, 'data-device': 'iphone'}))
 
 (TODO) Document for addtional settings will be added, soon. :^D
 

--- a/django_summernote/admin.py
+++ b/django_summernote/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.db import models
 from django_summernote.widgets import SummernoteWidget, SummernoteInplaceWidget
 from django_summernote.models import Attachment
-from django_summernote.settings import summernote_config
+from django_summernote.settings import summernote_config, get_attachment_model
 
 __widget__ = SummernoteWidget if summernote_config['iframe'] \
     else SummernoteInplaceWidget
@@ -21,4 +21,4 @@ class AttachmentAdmin(admin.ModelAdmin):
     search_fields = ['name']
     ordering = ('-id',)
 
-admin.site.register(Attachment, AttachmentAdmin)
+admin.site.register(get_attachment_model(), AttachmentAdmin)

--- a/django_summernote/models.py
+++ b/django_summernote/models.py
@@ -10,7 +10,7 @@ except ImportError:
 from django_summernote.settings import summernote_config
 
 
-__all__ = ['Attachment', ]
+__all__ = ['AbstractAttachment', 'Attachment', ]
 
 
 # module importer code comes from
@@ -47,7 +47,8 @@ def _get_attachment_storage():
         return default_storage
 
 
-class Attachment(models.Model):
+class AbstractAttachment(models.Model):
+
     name = models.CharField(max_length=255, null=True, blank=True)
     file = models.FileField(
         upload_to=summernote_config['attachment_upload_to'],
@@ -57,3 +58,11 @@ class Attachment(models.Model):
 
     def __unicode__(self):
         return u"%s" % (self.name)
+
+    class Meta:
+        abstract = True
+
+
+class Attachment(AbstractAttachment):
+
+    pass

--- a/django_summernote/settings.py
+++ b/django_summernote/settings.py
@@ -1,7 +1,9 @@
 import os
 import uuid
 from datetime import datetime
+from django.apps import apps as django_apps
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 
 def uploaded_filepath(instance, filename):
@@ -9,6 +11,20 @@ def uploaded_filepath(instance, filename):
     filename = "%s.%s" % (uuid.uuid4(), ext)
     today = datetime.now().strftime('%Y-%m-%d')
     return os.path.join('django-summernote', today, filename)
+
+
+def get_attachment_model():
+    """
+    Returns the Attachment model that is active in this project.
+    """
+    try:
+        return django_apps.get_model(summernote_config["attachment_model"])
+    except ValueError:
+        raise ImproperlyConfigured("SUMMERNOTE_CONFIG['attachment_model'] must be of the form 'app_label.model_name'")
+    except LookupError:
+        raise ImproperlyConfigured(
+            "SUMMERNOTE_CONFIG['attachment_model'] refers to model '%s' that has not been installed" % summernote_config["attachment_model"]
+        )
 
 
 SETTINGS_USER = getattr(settings, 'SUMMERNOTE_CONFIG', {})
@@ -75,6 +91,7 @@ SETTINGS_DEFAULT = {
     'attachment_storage_class': None,
     'attachment_filesize_limit': 1024 * 1024,
     'attachment_require_authentication': False,
+    'attachment_model': 'django_summernote.Attachment',
 
     'inplacewidget_external_css': (
         '//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css',
@@ -88,3 +105,4 @@ SETTINGS_DEFAULT = {
 
 summernote_config = SETTINGS_DEFAULT.copy()
 summernote_config.update(SETTINGS_USER)
+

--- a/django_summernote/templates/django_summernote/widget_iframe_editor.html
+++ b/django_summernote/templates/django_summernote/widget_iframe_editor.html
@@ -71,12 +71,14 @@
                 },
                 onImageUpload: function(files) {
                     var sn = $(this);
+                    // custom attachment data
+                    var attachmentData = src.dataset;
                     imageInput = $('.note-image-input');
                     imageInput.fileupload();
                     var jqXHR = imageInput.fileupload('send', 
                         {
                             files: files,
-                            formData: {csrfmiddlewaretoken: '{{ csrf_token }}'},
+                            formData: $.extend({csrfmiddlewaretoken: '{{ csrf_token }}'}, attachmentData),
                             url: settings.url.upload_attachment,
                         })
                         .success(function (result, textStatus, jqXHR) {

--- a/django_summernote/templates/django_summernote/widget_inplace.html
+++ b/django_summernote/templates/django_summernote/widget_inplace.html
@@ -46,11 +46,13 @@ $(function() {
             onImageUpload: function(files) {
                 var imageInput = $('.note-image-input');
                 var sn = $(this);
+                // custom attachment data
+                var attachmentData = {{ id }}_textarea.dataset;
                 imageInput.fileupload();
                 var jqXHR = imageInput.fileupload('send', 
                     {
                         files: files,
-                        formData: {csrfmiddlewaretoken: csrftoken},
+                        formData: $.extend({csrfmiddlewaretoken: csrftoken}, attachmentData),
                         url: {{ id }}_settings.url.upload_attachment,
                     })
                     .success(function (result, textStatus, jqXHR) {

--- a/django_summernote/tests.py
+++ b/django_summernote/tests.py
@@ -3,7 +3,7 @@ from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.test import TestCase, Client
-from django_summernote.settings import summernote_config
+from django_summernote.settings import summernote_config, get_attachment_model
 from imp import reload
 
 
@@ -130,7 +130,7 @@ class DjangoSummernoteTest(TestCase):
 
         from django_summernote.models import \
             Attachment, _get_attachment_storage
-        file_field = Attachment._meta.get_field_by_name('file')[0]
+        file_field = get_attachment_model()._meta.get_field_by_name('file')[0]
         original_storage = file_field.storage
         file_field.storage = _get_attachment_storage()
 
@@ -170,7 +170,7 @@ class DjangoSummernoteTest(TestCase):
         # IOError with patching storage class
         from django_summernote.models import Attachment
         from dummyplug.storage import IOErrorStorage
-        file_field = Attachment._meta.get_field_by_name('file')[0]
+        file_field = get_attachment_model()._meta.get_field_by_name('file')[0]
         original_storage = file_field.storage
         file_field.storage = IOErrorStorage()
 


### PR DESCRIPTION
- Added new feature to use "custom attachment model" for holding additional data fields.
- Additional parameters can be passed to both widgets as attributes (starting with "-data").

Proposed approach:

- Exposing a new abstract model "AbstractAttachment", available to be subclassed.
- New method settings.get_attachment_model() is used to determine appropriate Attachment model (default: django_summernote.Attachment).
- Additional attributes parameters are collected in widget JavaScript and POSTed back to server as data body.