### PR TITLE
Allow per-widget attrs to override summernote config

### DIFF
--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -33,11 +33,11 @@ def _get_proper_language():
 class SummernoteWidgetBase(forms.Textarea):
     def template_contexts(self):
         return {
-            'toolbar': summernote_config['toolbar'],
+            'toolbar': self.attrs.get('toolbar', summernote_config['toolbar']),
             'lang': _get_proper_language(),
-            'airMode': summernote_config['airMode'],
-            'styleWithSpan': summernote_config['styleWithSpan'],
-            'direction': summernote_config['direction'],
+            'airMode': self.attrs.get('airMode', summernote_config['airMode']),
+            'styleWithSpan': self.attrs.get('styleWithSpan', summernote_config['styleWithSpan']),
+            'direction': self.attrs.get('direction', summernote_config['direction']),
             'width': self.attrs.get('width', summernote_config['width']),
             'height': self.attrs.get('height', summernote_config['height']),
             'url': {


### PR DESCRIPTION
The documentation says:

> Or, you can styling editor via attributes of the widget. These adhoc styling will override settings from

This updates the per-widget settings so that toolbars, airMode, etc. can be set per-widget.