### PR TITLE
Added test for custom attachment model

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ In settings.py,
         # Set custom storage class for attachments.
         'attachment_storage_class': 'my.custom.storage.class.name',
 
-        # Set custom model for attachments.
-        'attachment_model': 'django_summernote.Attachment',
+        # Set custom model for attachments (default: 'django_summernote.Attachment')
+        'attachment_model': 'my.custom.attachment.model', # must inherit 'django_summernote.AbstractAttachment'
 
         # Set external media files for SummernoteInplaceWidget.
         # !!! Be sure to put {{ form.media }} in template before initiate summernote.

--- a/django_summernote/settings.py
+++ b/django_summernote/settings.py
@@ -18,7 +18,7 @@ def get_attachment_model():
     Returns the Attachment model that is active in this project.
     """
     try:
-        from models import AbstractAttachment
+        from .models import AbstractAttachment
         klass = django_apps.get_model(summernote_config["attachment_model"])
         if not issubclass(klass, AbstractAttachment):
             raise ImproperlyConfigured(

--- a/django_summernote/settings.py
+++ b/django_summernote/settings.py
@@ -18,7 +18,14 @@ def get_attachment_model():
     Returns the Attachment model that is active in this project.
     """
     try:
-        return django_apps.get_model(summernote_config["attachment_model"])
+        from models import AbstractAttachment
+        klass = django_apps.get_model(summernote_config["attachment_model"])
+        if not issubclass(klass, AbstractAttachment):
+            raise ImproperlyConfigured(
+                "SUMMERNOTE_CONFIG['attachment_model'] refers to model '%s' that is not "
+                "inherited from 'django_summernote.models.AbstractAttachment'" % summernote_config["attachment_model"]
+            )
+        return klass
     except ValueError:
         raise ImproperlyConfigured("SUMMERNOTE_CONFIG['attachment_model'] must be of the form 'app_label.model_name'")
     except LookupError:

--- a/django_summernote/tests.py
+++ b/django_summernote/tests.py
@@ -182,6 +182,27 @@ class DjangoSummernoteTest(TestCase):
 
         file_field.storage = original_storage
 
+    def test_get_attachment_model(self):
+        from django.core.exceptions import ImproperlyConfigured
+
+        # ValueError
+        summernote_config['attachment_model'] = \
+            'wow_no_dot_model_designation'
+        with self.assertRaises(ImproperlyConfigured):
+            get_attachment_model()
+
+        # LookupError
+        summernote_config['attachment_model'] = \
+            'wow.not.installed.app.model'
+        with self.assertRaises(ImproperlyConfigured):
+            get_attachment_model()
+
+        # Ensures proper inheritance, using built-in User class to test
+        summernote_config['attachment_model'] = \
+            'auth.User'
+        with self.assertRaises(ImproperlyConfigured):
+            get_attachment_model()
+
     def test_attachment_bad_request(self):
         url = reverse('django_summernote-upload_attachment')
         response = self.client.get(url)


### PR DESCRIPTION
- Added simple test for custom attachment model
- Ensure ImproperlyConfigured exception is raised when model specified in SUMMERNOTE_CONFIG["attachment_model"] is not inherited from AbstractAttachment.