### PR TITLE
Delete from the README of syncdb command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ SETUP
 
 4. Run `syncdb` for preparing attachment model.
 
-        python manage.py syncdb
-
+        python manage.py makemigrations django_summernote
+        python manage.py migrate
 
 USAGE
 -----


### PR DESCRIPTION
`manage.py syncdb` has been removed in the latest of Django.

So I fixed README.

--

https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9
> The syncdb command is removed.