### PR TITLE
using the another comment style to avoid corruption in runtime inline…

### DIFF
--- a/django_summernote/templates/django_summernote/widget_iframe_editor.html
+++ b/django_summernote/templates/django_summernote/widget_iframe_editor.html
@@ -16,9 +16,9 @@
         var iframe = window.parent.document.getElementById('{{ id }}_iframe');
         var src = window.parent.document.getElementById('{{ id_src }}');
         var imageInput = null;
-        $(src).hide(); // for IE
+        $(src).hide(); /* for IE */
 
-        // get settings from parent window
+        /* get settings from parent window */
         var settings = window.parent.settings_{{ id }};
 
         // include summernote language pack, synchronously


### PR DESCRIPTION
If you remove the lines from javascript to make a partial compress, the double slashes comment all the rest of the line. Comment style changed to avoid this behavior