### PR TITLE
Allow inplace widget to honor disable_upload setting.

### DIFF
--- a/django_summernote/templates/django_summernote/widget_inplace.html
+++ b/django_summernote/templates/django_summernote/widget_inplace.html
@@ -35,6 +35,7 @@ $(function() {
             onBlur: function() {
                 {{ id }}_textarea.value = $(this).summernote('code');
             },
+            {% if not disable_upload %}
             onImageUpload: function(files) {
                 var imageInput = $('.note-image-input');
                 var sn = $(this);
@@ -58,6 +59,7 @@ $(function() {
                         alert( 'Got an error while uploading images.' );
                     });
             }
+            {% endif %}
         }
     }));
 

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -136,6 +136,7 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
                 'value': value if value else '',
                 'settings': json.dumps(self.template_contexts()),
                 'STATIC_URL': settings.STATIC_URL,
+                'disable_upload': summernote_config['disable_upload'],
             }))
         )
         return mark_safe(html)


### PR DESCRIPTION
This is a fixup for PR #126 commits 4faa7e4 - Ability to enable/disable
upload images.

That update provided a 'disable_upload' setting which is then honored
in the iframe widget, but did not include cooresponding updates for the
inplace widget.

This commit includes two changes:
1. widget_inplace.html: Mirror the if..endif logic from
   widget_iframe_editor.html to prevent defining onImageUpload if
   disable_upload is True.
2. widgets.SummernoteInplaceWidget.render: Mirror the update to
   views.editor, placing the value of disable_upload in the render context
   for the inplace widget.