### PR TITLE
Added missing CSRF_COOKIE_NAME to inplace widget (fixes #165)

### DIFF
--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -135,8 +135,9 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
                 'id_src': attrs['id'],
                 'value': value if value else '',
                 'settings': json.dumps(self.template_contexts()),
-                'STATIC_URL': settings.STATIC_URL,
                 'disable_upload': summernote_config['disable_upload'],
+                'STATIC_URL': settings.STATIC_URL,
+                'CSRF_COOKIE_NAME': settings.CSRF_COOKIE_NAME,
             }))
         )
         return mark_safe(html)


### PR DESCRIPTION
This fixes file upload from inplace widget, which was broken in #155. This closes #165.