### PR TITLE
ignore pycharm configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ coverage.xml
 
 # Virtual environments, e.g. virtualenv
 venv
+
+# PyCharm
+.idea/*


### PR DESCRIPTION
I use PyCharm IDE which generates .idea files for configurations.

I want them to be ignored.