### PR TITLE
- travis-ci build error fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - pip install -q -U pip setuptools tox tox-travis codecov
+  - pip install -q -U pip tox tox-travis codecov
 script:
   - tox
 after_success:


### PR DESCRIPTION
Hello,

I just removed "setuptools" in order not to install for travis-ci test.

I'm not sure what's wrong, but it now builds successfully.

[travis-ci build result](https://travis-ci.org/pincoin/django-summernote)

Thank you.
