### PR TITLE
- jQuery 3.x AJAX API compatible

### DIFF
--- a/django_summernote/static/django_summernote/jquery.iframe-transport.js
+++ b/django_summernote/static/django_summernote/jquery.iframe-transport.js
@@ -6,12 +6,12 @@
  * https://blueimp.net
  *
  * Licensed under the MIT license:
- * http://www.opensource.org/licenses/MIT
+ * https://opensource.org/licenses/MIT
  */
 
-/* global define, require, window, document */
+/* global define, require, window, document, JSON */
 
-(function (factory) {
+;(function (factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // Register as an anonymous AMD module:
@@ -27,7 +27,14 @@
     'use strict';
 
     // Helper variable to create unique names for the transport iframes:
-    var counter = 0;
+    var counter = 0,
+        jsonAPI = $,
+        jsonParse = 'parseJSON';
+
+    if ('JSON' in window && 'parse' in JSON) {
+      jsonAPI = JSON;
+      jsonParse = 'parse';
+    }
 
     // The iframe transport accepts four additional options:
     // options.fileInput: a jQuery collection of file input fields
@@ -197,7 +204,7 @@
                 return iframe && $(iframe[0].body).text();
             },
             'iframe json': function (iframe) {
-                return iframe && $.parseJSON($(iframe[0].body).text());
+                return iframe && jsonAPI[jsonParse]($(iframe[0].body).text());
             },
             'iframe html': function (iframe) {
                 return iframe && $(iframe[0].body).html();

--- a/django_summernote/templates/django_summernote/widget_iframe_editor.html
+++ b/django_summernote/templates/django_summernote/widget_iframe_editor.html
@@ -84,12 +84,12 @@
                             formData: $.extend({csrfmiddlewaretoken: '{{ csrf_token }}'}, attachmentData),
                             url: settings.url.upload_attachment,
                         })
-                        .success(function (data, textStatus, jqXHR) {
+                        .done(function (data, textStatus, jqXHR) {
                             $.each(data.files, function (index, file) {
                                 sn.summernote("insertImage", file.url);
                             });
                         })
-                        .error(function (jqXHR, textStatus, errorThrown) {
+                        .fail(function (jqXHR, textStatus, errorThrown) {
                             // if the error message from the server has any text in it, show it
                             var msg = jqXHR.responseText;
                             if (msg.length > 0) {

--- a/django_summernote/templates/django_summernote/widget_inplace.html
+++ b/django_summernote/templates/django_summernote/widget_inplace.html
@@ -57,12 +57,12 @@ $(function() {
                         formData: $.extend({csrfmiddlewaretoken: csrftoken}, attachmentData),
                         url: {{ id }}_settings.url.upload_attachment,
                     })
-                    .success(function (data, textStatus, jqXHR) {
+                    .done(function (data, textStatus, jqXHR) {
                         $.each(data.files, function (index, file) {
                             sn.summernote("insertImage", file.url);
                         });
                     })
-                    .error(function (jqXHR, textStatus, errorThrown) {
+                    .fail(function (jqXHR, textStatus, errorThrown) {
                         // if the error message from the server has any text in it, show it
                         var msg = jqXHR.responseText;
                         if (msg.length > 0) {


### PR DESCRIPTION
Hello,

The [jQuery official documents](http://api.jquery.com/jquery.ajax/) notify the deprecated API:

> Deprecation Notice: The jqXHR.success(), jqXHR.error(), and jqXHR.complete() callbacks are removed as of jQuery 3.0. You can use jqXHR.done(), jqXHR.fail(), and jqXHR.always() instead.

I substituted jQuery Ajax function `success()` and `error()` to `done()` and `fail()`.

jQuery 1.x and 2.x support both `success()` and `done()`. That's why this PR works fine with jQuery 1.x, 2.x and 3.x.

I also upgraded jQuery-File-Upload version to v9.19.0.

Thank you.