### PR TITLE
Remove duplicate css/js declarations

### DIFF
--- a/django_summernote/settings.py
+++ b/django_summernote/settings.py
@@ -109,14 +109,19 @@ SETTINGS_DEFAULT = {
     'attachment_require_authentication': False,
     'attachment_model': 'django_summernote.Attachment',
 
+    'base_css': (
+        '//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css',
+    ),
+    'base_js': (
+        '//code.jquery.com/jquery-3.2.1.min.js',
+        '//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js',
+    ),
+
     'default_css': (
-        '//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css',
         static_url('django_summernote/summernote.css'),
         static_url('django_summernote/django_summernote.css'),
     ),
     'default_js': (
-        '//code.jquery.com/jquery-1.9.1.min.js',
-        '//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js',
         static_url('django_summernote/jquery.ui.widget.js'),
         static_url('django_summernote/jquery.iframe-transport.js'),
         static_url('django_summernote/jquery.fileupload.js'),
@@ -126,17 +131,6 @@ SETTINGS_DEFAULT = {
     'css': (),
     'js': (),
 
-    'default_css_for_inplace': (
-        static_url('django_summernote/summernote.css'),
-        static_url('django_summernote/django_summernote_inplace.css'),
-    ),
-    'default_js_for_inplace': (
-        static_url('django_summernote/jquery.ui.widget.js'),
-        static_url('django_summernote/jquery.iframe-transport.js'),
-        static_url('django_summernote/jquery.fileupload.js'),
-        static_url('django_summernote/summernote.min.js'),
-        static_url('django_summernote/ResizeSensor.js'),
-    ),
     'css_for_inplace': (),
     'js_for_inplace': (),
     # Disable upload

--- a/django_summernote/views.py
+++ b/django_summernote/views.py
@@ -13,10 +13,12 @@ def editor(request, id):
             'id_src': id,
             'id': id.replace('-', '_'),
             'css': (
+                summernote_config['base_css'] +
                 summernote_config['default_css'] +
                 summernote_config['css']
             ),
             'js': (
+                summernote_config['base_js'] +
                 summernote_config['default_js'] +
                 summernote_config['js']
             ),

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -114,13 +114,13 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
     class Media:
         css = {
             'all': (
-                summernote_config['default_css_for_inplace'] +
+                summernote_config['default_css'] +
                 summernote_config['css_for_inplace']
             )
         }
 
         js = (
-            summernote_config['default_js_for_inplace'] +
+            summernote_config['default_js'] +
             summernote_config['js_for_inplace']
         )
 


### PR DESCRIPTION
Hello,

I removed duplicate css/js declarations, and it is just code refactoring not related to features.

I often made a mistake to test several library versions like jquery, bootstrap, jquery-file-upload.

* `base_css` and `base_js` declare its environment such as jQuery and Bootstrap.
* `default_css` and `default_js` delcare the summernote itself.
* `css` and `js` can be used for additional declarations for `SummernoteWidget`.
* `css_for_inplace` and `js_for_inplace` can be used for additional declarations for `SummernoteInplaceWidget`.

I also updated the jQuery and Bootstrap version for `SummernoteWidget`.

Please, review the code and accept this PR.

Thank you.