### PR TITLE
Add jquery variable setting to use another name

### DIFF
--- a/django_summernote/settings.py
+++ b/django_summernote/settings.py
@@ -109,6 +109,8 @@ SETTINGS_DEFAULT = {
     'attachment_require_authentication': False,
     'attachment_model': 'django_summernote.Attachment',
 
+    'jquery': '$',
+
     'base_css': (
         '//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css',
     ),
@@ -133,6 +135,7 @@ SETTINGS_DEFAULT = {
 
     'css_for_inplace': (),
     'js_for_inplace': (),
+
     # Disable upload
     'disable_upload': False,
 }

--- a/django_summernote/templates/django_summernote/widget_iframe_editor.html
+++ b/django_summernote/templates/django_summernote/widget_iframe_editor.html
@@ -12,7 +12,7 @@
         <div id="summernote"></div>
     </body>
     <script>
-    $(function() {
+    {{ jquery }}(document).ready(function($) {
         var iframe = window.parent.document.getElementById('{{ id }}_iframe');
         var src = window.parent.document.getElementById('{{ id_src }}');
         var imageInput = null;

--- a/django_summernote/templates/django_summernote/widget_inplace.html
+++ b/django_summernote/templates/django_summernote/widget_inplace.html
@@ -1,7 +1,7 @@
 {% load staticfiles %}
 <div id='{{ id_src }}'>{{ value|safe }}</div>
 <script>
-$(function() {
+{{ jquery }}(document).ready(function($) {
     var {{ id }}_textarea = window.document.getElementById('{{ id_src }}-textarea');
     var {{ id }}_src = window.document.getElementById('{{ id_src }}');
     var {{ id }}_settings = {{ settings|safe }};

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -101,6 +101,7 @@ class SummernoteWidget(SummernoteWidgetBase):
                 'id_src': attrs['id'],
                 'src': url,
                 'attrs': flatatt(final_attrs),
+                'jquery': summernote_config['jquery'],
                 'width': contexts['width'],
                 'height': contexts['height'],
                 'settings': json.dumps(contexts),
@@ -136,6 +137,7 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
             {
                 'id': attrs['id'].replace('-', '_'),
                 'id_src': attrs['id'],
+                'jquery': summernote_config['jquery'],
                 'value': value if value else '',
                 'settings': json.dumps(self.template_contexts()),
                 'disable_upload': summernote_config['disable_upload'],


### PR DESCRIPTION
For https://github.com/summernote/django-summernote/issues/53
Now we can use different name for calling `jQuery`.