### PR TITLE
Python setuptools classifiers updated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
Hello,

Our `django-summernote` package supports 3.6 Python.

We need to update the package meta information.

Thank you.