### PR TITLE
Exclude djs_playground package explicitly

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include django_summernote *
+recursive-exclude djs_playground *
 
 global-exclude *.pyc

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,9 @@ for directory in ['static', 'templates']:
 setup(
     name=PROJECT,
     version=version,
-    packages=find_packages(),
+    packages=find_packages(exclude=(
+        'djs_playground',
+    )),
     package_data={'': PACKAGE_DATA, },
     zip_safe=False,
 


### PR DESCRIPTION
Hello,

`djs_playground` package was added, but it shouldn't be included in PyPI package.

`find_package()` searches all the available packages, and `djs_playground` has `__init__.py`. That's why this package is added automatically although `manage.py` is not included in PyPI package.

Thank you.