### PR TITLE
Allow user can add external plugin settings via dict.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,19 @@ In settings.py,
         # If you want to initialize summernote at the bottom of page, set this as True
         # and call `initSummernote()` on your page.
         'lazy': True,
+
+        # To use external plugins,
+        # Include them within `css` and `js`.
+        'js': {
+            '/some_static_folder/summernote-ext-print.js',
+            '//somewhere_in_internet/summernote-plugin-name.js',
+        }
+        # You can also add custom settings in `summernote` section.
+        'summernote': {
+            'print': {
+                'stylesheetUrl': '/some_static_folder/printable.css',
+            },
+        }
     }
 
   - There are pre-defined css/js files for widgets.

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -78,6 +78,8 @@ class SummernoteWidgetBase(forms.Textarea):
                     v = str(v)
                 contexts[option] = v
 
+        # Merge 'summernote' dict as it is.
+        contexts.update(summernote_config.get('summernote', {}))
         return contexts
 
     def value_from_datadict(self, data, files, name):


### PR DESCRIPTION
This patch allows user can add external plugin settings via dict.
Like this;
```
SUMMERNOTE_CONFIG = {                                                               
    'summernote': {                                                                 
        'print': {                                                                  
            'stylesheetUrl': '/static/print.css',                                   
        },                                                                          
    },                                                                              
    'js': (                                                                         
        '/static/summernote-ext-print.js',                                          
    ),  
}
```