### PR TITLE
fix multiplying '/static/' prefix

### DIFF
--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -130,9 +130,6 @@ class SummernoteWidget(SummernoteWidgetBase):
 class SummernoteInplaceWidget(SummernoteWidgetBase):
     @property
     def media(self):
-        summernote_config['default_css'] = tuple(static(x) for x in summernote_config['default_css'])
-        summernote_config['default_js'] = tuple(static(x) for x in summernote_config['default_js'])
-
         return forms.Media(
             css={
                 'all': (


### PR DESCRIPTION
the `SummernoteInplaceWidget` new `media` property introduced a regression where after successive reloads the widget stops working as the static files 'get lost'.  the more reloads, the more static it gets :}

```
<script type="text/javascript" src="/static/static/static/summernote/jquery.ui.widget.js"></script>
<script type="text/javascript" src="/static/static/static/summernote/jquery.iframe-transport.js"></script>
<script type="text/javascript" src="/static/static/static/summernote/jquery.fileupload.js"></script>
<script type="text/javascript" src="/static/static/static/summernote/summernote.min.js"></script>
<script type="text/javascript" src="/static/static/static/summernote/ResizeSensor.js"></script>
```

using `static()` seems to be [unnecessary](https://docs.djangoproject.com/en/1.11/topics/forms/media/#form-asset-paths):

> To find the appropriate prefix to use, Django will check if the STATIC_URL setting is not None and automatically fall back to using MEDIA_URL.

i think that there is no advantage here to use the `@property` over the simpler `Media` `class` but in the patch i did not change it back.
