### PR TITLE
Dropping support under Django 1.7

### DIFF
--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -11,13 +11,7 @@ from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
-
-try:
-    # Django >= 1.7
-    from django.forms.utils import flatatt
-except ImportError:
-    # Django < 1.7
-    from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django_summernote.settings import summernote_config
 from django.conf import settings
 


### PR DESCRIPTION
As see [Django's roadmap](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&ved=0ahUKEwjHo8Kg8c7XAhVGe7wKHQXJDOkQFgglMAA&url=https%3A%2F%2Fwww.djangoproject.com%2Fweblog%2F2015%2Fjun%2F25%2Froadmap%2F&usg=AOvVaw2YvmZ2NGXcJYzMz0zGba_2), we do not have to support under Django 1.7 at all. So I dropped it.