### PR TITLE
Drop support under Python 2.7

### DIFF
--- a/django_summernote/models.py
+++ b/django_summernote/models.py
@@ -2,11 +2,7 @@ from __future__ import unicode_literals
 from django.db import models
 from django.core.files.storage import default_storage
 from django.core.exceptions import ImproperlyConfigured
-
-try:
-    from importlib import import_module
-except ImportError:
-    from django.utils.importlib import import_module
+from importlib import import_module
 
 from django_summernote.settings import summernote_config
 


### PR DESCRIPTION
We're already dropped support under Python 2.7, but we're still using a try-except block for them. So I removed it.