### PR TITLE
form assets error fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ venv
 # Sample database and files
 *.sqlite3
 djs_playground/media
+djs_playground/static

--- a/django_summernote/views.py
+++ b/django_summernote/views.py
@@ -1,3 +1,4 @@
+from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.template.loader import render_to_string
@@ -7,14 +8,17 @@ from django_summernote.settings import summernote_config, get_attachment_model
 
 
 def editor(request, id):
+    static_default_css = tuple(static(x) for x in summernote_config['default_css'])
+    static_default_js = tuple(static(x) for x in summernote_config['default_js'])
+
     css = summernote_config['base_css'] \
           + (summernote_config['codemirror_css'] if 'codemirror' in summernote_config else ()) \
-          + summernote_config['default_css'] \
+          + static_default_css \
           + summernote_config['css']
 
     js = summernote_config['base_js'] \
          + (summernote_config['codemirror_js'] if 'codemirror' in summernote_config else ()) \
-         + summernote_config['default_js'] \
+         + static_default_js \
          + summernote_config['js']
 
     return render(

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -122,24 +122,18 @@ class SummernoteWidget(SummernoteWidgetBase):
 
 
 class SummernoteInplaceWidget(SummernoteWidgetBase):
-    @property
-    def media(self):
-        summernote_config['default_css'] = tuple(static(x) for x in summernote_config['default_css'])
-        summernote_config['default_js'] = tuple(static(x) for x in summernote_config['default_js'])
-
-        return forms.Media(
-            css={
-                'all': (
-                    (summernote_config['codemirror_css'] if 'codemirror' in summernote_config else ()) +
-                    summernote_config['default_css'] +
-                    summernote_config['css_for_inplace']
-                )
-            },
-            js=(
-                (summernote_config['codemirror_js'] if 'codemirror' in summernote_config else ()) +
-                summernote_config['default_js'] +
-                summernote_config['js_for_inplace']
+    class Media:
+        css = {
+            'all': (
+                (summernote_config['codemirror_css'] if 'codemirror' in summernote_config else ()) +
+                summernote_config['default_css'] +
+                summernote_config['css_for_inplace']
             )
+        }
+        js = (
+            (summernote_config['codemirror_js'] if 'codemirror' in summernote_config else ()) +
+            summernote_config['default_js'] +
+            summernote_config['js_for_inplace']
         )
 
     def render(self, name, value, attrs=None):

--- a/djs_playground/views.py
+++ b/djs_playground/views.py
@@ -6,11 +6,11 @@ from django_summernote.widgets import SummernoteWidget, SummernoteInplaceWidget
 
 class SampleForm(forms.Form):
     desc1 = forms.CharField(
-        label='',
+        label='iframe',
         widget=SummernoteWidget()
     )
     desc2 = forms.CharField(
-        label='',
+        label='in place',
         widget=SummernoteInplaceWidget()
     )
 


### PR DESCRIPTION
Hello,

Thanks to #245 @minusf, I was able to find my faults that I made two widgets mangled.

I changed the code as follows:

1. `SummernoteInplaceWidget` uses static definition as before.
2. `SummernoteWidget` renders static path of assets in `django_summernote/views.py`.

I really appreciate @minusf PR, but I also agree that static definition could be better than dynamic property.

Therefore, @minusf PR could be turned down if this PR is accepted.

Thank you.