### PR TITLE
django 2.0 supported

### DIFF
--- a/django_summernote/test_settings.py
+++ b/django_summernote/test_settings.py
@@ -1,3 +1,5 @@
+import django
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -5,13 +7,22 @@ DATABASES = {
     }
 }
 
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
-)
+if django.VERSION <= (1, 9):
+    MIDDLEWARE_CLASSES = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.middleware.locale.LocaleMiddleware',
+    )
+else:
+    MIDDLEWARE = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.middleware.locale.LocaleMiddleware',
+    )
 
 STATIC_URL = '/'
 MEDIA_ROOT = 'test_media'

--- a/django_summernote/tests.py
+++ b/django_summernote/tests.py
@@ -326,7 +326,7 @@ class DjangoSummernoteTest(TestCase):
 
         class SimpleModel2(models.Model):
             foobar = models.TextField()
-            parent = models.ForeignKey(SimpleParentModel)
+            parent = models.ForeignKey(SimpleParentModel, on_delete=models.DO_NOTHING)
 
         class SimpleModelInline(SummernoteInlineModelAdmin):
             model = SimpleModel2

--- a/django_summernote/views.py
+++ b/django_summernote/views.py
@@ -1,3 +1,4 @@
+import django
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
@@ -43,7 +44,8 @@ def upload_attachment(request):
         }, status=400)
 
     if summernote_config['attachment_require_authentication']:
-        if not request.user.is_authenticated():
+        if django.VERSION < (2, 0) and not request.user.is_authenticated() \
+                or not request.user.is_authenticated:
             return JsonResponse({
                 'status': 'false',
                 'message': _('Only authenticated users are allowed'),

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    {py27,py34,py35}-{dj108,dj109,dj110,dj111},
-    {py36}-{dj111}
+    {py27}-{dj108,dj111},
+    {py34,py35}-{dj108,dj111,dj200}
+    {py36}-{dj111,dj200}
 
 [tox:travis]
 2.7 = py27
@@ -19,9 +20,8 @@ basepython =
 deps =
     coverage
     dj108: Django<1.9
-    dj109: Django<1.10
-    dj110: Django<1.11
     dj111: Django<1.12
+    dj200: Django<2.1
     djmaster: https://github.com/django/django/archive/master.tar.gz
 
 commands = coverage run -a setup.py test


### PR DESCRIPTION
Hello,

- MIDDLEWARE instead of MIDDLEWARE_CLASSES as of Django 1.10.
- Cascaded option specified for Foreign key
- Using User.is_authenticated() as methods rather than properties is no longer supported as of Django 2.0
- Django 2.0 does NOT support Python 2.x.