### PR TITLE
Fixes ResizeSensor.js: TypeError: window.getComputedStyle(...) is null

### DIFF
--- a/django_summernote/static/summernote/ResizeSensor.js
+++ b/django_summernote/static/summernote/ResizeSensor.js
@@ -98,11 +98,17 @@
          * @returns {String|Number}
          */
         function getComputedStyle(element, prop) {
+            var computedElementStyle;
+            
             if (element.currentStyle) {
                 return element.currentStyle[prop];
             }
+            
             if (window.getComputedStyle) {
-                return window.getComputedStyle(element, null).getPropertyValue(prop);
+                computedElementStyle = window.getComputedStyle(element, null);
+                if (computedElementStyle) {
+                    return computedElementStyle.getPropertyValue(prop);
+                }
             }
 
             return element.style[prop];


### PR DESCRIPTION
Fix from @shapeshifta78 https://github.com/marcj/css-element-queries/pull/154

