### PR TITLE
Fix SummernoteInplaceWidget full screen not work bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In `admin.py`,
 
     # Apply summernote to all TextField in model.
     class SomeModelAdmin(SummernoteModelAdmin):  # instead of ModelAdmin
-        ...
+        summer_note_fields = '__all__'
 
     admin.site.register(SomeModel, SomeModelAdmin)
 
@@ -69,22 +69,11 @@ Although `Post` model has several TextField, only `content` field will have `Sum
 
 In `admin.py`,
 
-    from django import forms
-    from django.contrib import admin
-    from django_summernote.widgets import SummernoteWidget    
+    from django_summernote.admin import SummernoteModelAdmin
     from .models import Post
-
-    class PostAdminForm(forms.ModelForm):
-        class Meta:
-            model = Post
-            widgets = {
-                'content': SummernoteWidget(),
-            }
-            fields = '__all__'   
     
-    class PostAdmin(admin.ModelAdmin):
-        form = PostAdminForm
-        ...
+    class PostAdmin(SummernoteModelAdmin):
+        summer_note_fields = ('content',)
     
     admin.site.register(Post, PostAdmin)
 

--- a/django_summernote/admin.py
+++ b/django_summernote/admin.py
@@ -8,11 +8,29 @@ __widget__ = SummernoteWidget if summernote_config['iframe'] \
 
 
 class SummernoteInlineModelAdmin(admin.options.InlineModelAdmin):
-    formfield_overrides = {models.TextField: {'widget': __widget__}}
+    summer_note_fields = ()
+
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        if self.summer_note_fields == '__all__':
+            if isinstance(db_field, models.TextField):
+                kwargs['widget'] = __widget__
+        else:
+            if db_field.name in self.summer_note_fields:
+                kwargs['widget'] = __widget__
+        return super(SummernoteInlineModelAdmin, self).formfield_for_dbfield(db_field, **kwargs)
 
 
 class SummernoteModelAdmin(admin.ModelAdmin):
-    formfield_overrides = {models.TextField: {'widget': __widget__}}
+    summer_note_fields = ()
+
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        if self.summer_note_fields == '__all__':
+            if isinstance(db_field, models.TextField):
+                kwargs['widget'] = __widget__
+        else:
+            if db_field.name in self.summer_note_fields:
+                kwargs['widget'] = __widget__
+        return super(SummernoteModelAdmin, self).formfield_for_dbfield(db_field, **kwargs)
 
 
 class AttachmentAdmin(admin.ModelAdmin):
@@ -23,5 +41,6 @@ class AttachmentAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         obj.name = obj.file.name if (not obj.name) else obj.name
         super(AttachmentAdmin, self).save_model(request, obj, form, change)
+
 
 admin.site.register(get_attachment_model(), AttachmentAdmin)

--- a/django_summernote/admin.py
+++ b/django_summernote/admin.py
@@ -8,7 +8,7 @@ __widget__ = SummernoteWidget if summernote_config['iframe'] \
 
 
 class SummernoteInlineModelAdmin(admin.options.InlineModelAdmin):
-    summer_note_fields = ()
+    summer_note_fields = '__all__'
 
     def formfield_for_dbfield(self, db_field, **kwargs):
         if self.summer_note_fields == '__all__':
@@ -21,7 +21,7 @@ class SummernoteInlineModelAdmin(admin.options.InlineModelAdmin):
 
 
 class SummernoteModelAdmin(admin.ModelAdmin):
-    summer_note_fields = ()
+    summer_note_fields = '__all__'
 
     def formfield_for_dbfield(self, db_field, **kwargs):
         if self.summer_note_fields == '__all__':

--- a/django_summernote/templates/django_summernote/widget_common.html
+++ b/django_summernote/templates/django_summernote/widget_common.html
@@ -27,21 +27,12 @@ function initSummernote_{{ id }}() {
         function recalcHeight(e) {
             var nToolbar = e.find('.note-toolbar');
             var nEditable = e.find('.note-editable');
-{% if iframe %}
             var nEditor = $('.note-editor');
             var height = parseInt(
                 parseInt(settings.height)  // default
                 - nToolbar.outerHeight()  // toolbar height including margin,border,padding
                 - (nEditor.outerHeight() - nEditor.innerHeight())  // editor's border
             );
-{% else %}
-            var nStatusbar = e.find('.note-statusbar');
-            var height = parseInt(
-                parseInt(settings.height)  // default
-                - nToolbar.outerHeight()  // toolbar height including margin,border,padding
-                - nStatusbar.outerHeight()  // statusbar height including margin,border,padding
-            );
-{% endif %}
             nEditable.outerHeight(height);
         }
 
@@ -58,9 +49,11 @@ function initSummernote_{{ id }}() {
 
                     // Resize again when the height of note-toolbar changed
                     // This enhances calculation behaviors on Safari
+                {% if iframe %}
                     new ResizeSensor($nEditor.find('.note-toolbar'), function() {
                         recalcHeight($nEditor);
                     });
+                {% endif %}
 
                     // Move dropdown dialog when it exeeds the bound of the editor
                     $nEditor.find('.note-btn-group').on('shown.bs.dropdown', function () {


### PR DESCRIPTION
Call recalcHeight function in iframe only.Otherwise recalcHeight function will reset wysiwyg editor height after  wysiwyg editor been full screen in SummernoteInplaceWidget.