### PR TITLE
Django 1.11 compatibility issue

### DIFF
--- a/django_summernote/admin.py
+++ b/django_summernote/admin.py
@@ -1,3 +1,4 @@
+import django
 from django.contrib import admin
 from django.contrib.admin.options import InlineModelAdmin
 from django.db import models
@@ -11,15 +12,26 @@ __widget__ = SummernoteWidget if summernote_config['iframe'] \
 class SummernoteModelAdminMixin(object):
     summernote_fields = '__all__'
 
-    def formfield_for_dbfield(self, db_field, **kwargs):
-        if self.summernote_fields == '__all__':
-            if isinstance(db_field, models.TextField):
-                kwargs['widget'] = __widget__
-        else:
-            if db_field.name in self.summernote_fields:
-                kwargs['widget'] = __widget__
+    if django.VERSION >= (1, 10):
+        def formfield_for_dbfield(self, db_field, request, **kwargs):
+            if self.summernote_fields == '__all__':
+                if isinstance(db_field, models.TextField):
+                    kwargs['widget'] = __widget__
+            else:
+                if db_field.name in self.summernote_fields:
+                    kwargs['widget'] = __widget__
 
-        return super(SummernoteModelAdminMixin, self).formfield_for_dbfield(db_field, **kwargs)
+            return super(SummernoteModelAdminMixin, self).formfield_for_dbfield(db_field, request, **kwargs)
+    else:
+        def formfield_for_dbfield(self, db_field, **kwargs):
+            if self.summernote_fields == '__all__':
+                if isinstance(db_field, models.TextField):
+                    kwargs['widget'] = __widget__
+            else:
+                if db_field.name in self.summernote_fields:
+                    kwargs['widget'] = __widget__
+
+            return super(SummernoteModelAdminMixin, self).formfield_for_dbfield(db_field, **kwargs)
 
 
 class SummernoteInlineModelAdmin(SummernoteModelAdminMixin, InlineModelAdmin):


### PR DESCRIPTION
Unable to override dbfield. Arguments for formfield_for_dbfield has been changed since 1.10

https://github.com/django/django/commit/dbb0df2a0ec5bee80bee336fc81408efb30b7e47#diff-3c42de3e53aba87b32c494f995a728df