### PR TITLE
Widget-specific setting overrides

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
-0.8.8.6 - A lot of internal code changes 
+0.8.8.7 - Added ability to have widget-specific Summernote JS option overrides
+0.8.8.6 - A lot of internal code changes
 0.8.8.5 - Now we're supporting Django 2.0
 0.8.8.4 - Hotfix for handling static files
 0.8.8.3 - Fix a migration issue and minor bugs

--- a/README.md
+++ b/README.md
@@ -216,8 +216,9 @@ In settings.py,
             '/some_static_folder/summernote-ext-print.js',
             '//somewhere_in_internet/summernote-plugin-name.js',
         },
-        # You can also add custom settings in `summernote` section.
+        # You can also add custom Summernote JS settings in `summernote` section.
         'summernote': {
+            'disableDragAndDrop': False,
             'print': {
                 'stylesheetUrl': '/some_static_folder/printable.css',
             },
@@ -241,6 +242,18 @@ You can also pass additional parameters to custom `Attachment` model by adding a
     # Pass additional parameters to Attachment via attributes
     class SomeForm(forms.Form):
         foo = forms.CharField(widget=SummernoteWidget(attrs={'data-user-id': 123456, 'data-device': 'iphone'}))
+
+You can override Summernote JS custom options from `SUMMERNOTE_CONFIG` for each widget as well:
+
+    # Optionally set/override Summernote JS options for each widget
+    class SomeForm(forms.Form):
+        foo = forms.CharField(widget=SummernoteWidget(attrs={
+            'disable_upload': True,
+            'summernote': {
+                'disableDragAndDrop': True
+            }
+        }))
+
 
 LIMITATIONS
 -----------

--- a/README.md
+++ b/README.md
@@ -189,9 +189,6 @@ In settings.py,
         'js_for_inplace': (
         ),
 
-        # You can disable file upload feature.
-        'disable_upload': False,
-
         # Codemirror as codeview
         # If any codemirror settings are defined, it will include codemirror files automatically.
         'css': {
@@ -217,6 +214,7 @@ In settings.py,
             '//somewhere_in_internet/summernote-plugin-name.js',
         },
         # You can also add custom Summernote JS settings in `summernote` section.
+        # Disable file upload feature here.
         'summernote': {
             'disableDragAndDrop': False,
             'print': {
@@ -248,7 +246,6 @@ You can override Summernote JS custom options from `SUMMERNOTE_CONFIG` for each 
     # Optionally set/override Summernote JS options for each widget
     class SomeForm(forms.Form):
         foo = forms.CharField(widget=SummernoteWidget(attrs={
-            'disable_upload': True,
             'summernote': {
                 'disableDragAndDrop': True
             }

--- a/django_summernote/__init__.py
+++ b/django_summernote/__init__.py
@@ -1,4 +1,4 @@
-version_info = (0, 8, 8, 6)
+version_info = (0, 8, 8, 7)
 
 __version__ = version = '.'.join(map(str, version_info))
 __project__ = PROJECT = 'django-summernote'

--- a/django_summernote/settings.py
+++ b/django_summernote/settings.py
@@ -143,9 +143,6 @@ SETTINGS_DEFAULT = {
     'css_for_inplace': (),
     'js_for_inplace': (),
 
-    # Disable upload
-    'disable_upload': False,
-
     # For lazy loading (inplace widget only)
     'lazy': False,
 }

--- a/django_summernote/templates/django_summernote/widget_common.html
+++ b/django_summernote/templates/django_summernote/widget_common.html
@@ -73,8 +73,7 @@ function initSummernote_{{ id }}() {
                     onBlur: function() {
                         origin.value = $sn.summernote('code');
                     },
-                    {% if not disable_upload %}
-                    onImageUpload: function(files) {
+                    onImageUpload: settings.disableDragAndDrop ? null : function(files) {
                         // custom attachment data
                         var attachmentData = origin.dataset;
                         $nImageInput.fileupload();
@@ -101,7 +100,6 @@ function initSummernote_{{ id }}() {
                                 }
                             });
                     }
-                    {% endif %}
                 }
             }));
         };

--- a/django_summernote/views.py
+++ b/django_summernote/views.py
@@ -40,7 +40,6 @@ class SummernoteEditor(TemplateView):
         context['id'] = self.kwargs['id'].replace('-', '_')
         context['css'] = self.css
         context['js'] = self.js
-        context['disable_upload'] = summernote_config['disable_upload']
         context['jquery'] = summernote_config['jquery']
 
         return context

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -86,8 +86,12 @@ class SummernoteWidgetBase(forms.Textarea):
                     v = str(v)
                 contexts[option] = v
 
-        # Merge 'summernote' dict as it is.
+        # Merge default 'summernote' JS settings dict as it is.
         contexts.update(summernote_config.get('summernote', {}))
+
+        # Merge widget-specific 'summernote' JS settings dict as it is.
+        contexts.update(self.attrs.get('summernote', {}))
+
         return contexts
 
     def value_from_datadict(self, data, files, name):
@@ -165,8 +169,8 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
                 'jquery': summernote_config['jquery'],
                 'value': value if value else '',
                 'settings': json.dumps(self.template_contexts()),
-                'disable_upload': summernote_config['disable_upload'],
-                'lazy': summernote_config['lazy'],
+                'disable_upload': attrs.get('disable_upload', summernote_config['disable_upload']),
+                'lazy': attrs.get('lazy', summernote_config['lazy']),
                 'CSRF_COOKIE_NAME': settings.CSRF_COOKIE_NAME,
             }
         )

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -115,6 +115,10 @@ class SummernoteWidget(SummernoteWidgetBase):
         del final_attrs['id']  # Use original attributes without id.
 
         contexts = self.template_contexts()
+        # backward-compatible setting deprecation; disable
+        # via `summmernote` dict setting instead
+        if 'disable_upload' in summernote_config:
+            contexts['disableDragAndDrop'] = summernote_config['disable_upload']
 
         url = reverse('django_summernote-editor',
                       kwargs={'id': attrs['id']})
@@ -160,6 +164,12 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
         final_attrs = self.build_attrs(attrs)
         del final_attrs['id']  # Use original attributes without id.
 
+        contexts = self.template_contexts()
+        # backward-compatible setting deprecation; disable
+        # via `summmernote` dict setting instead
+        if 'disable_upload' in summernote_config:
+            contexts['disableDragAndDrop'] = summernote_config['disable_upload']
+
         html += render_to_string(
             'django_summernote/widget_inplace.html',
             {
@@ -168,8 +178,7 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
                 'attrs': flatatt(final_attrs),
                 'jquery': summernote_config['jquery'],
                 'value': value if value else '',
-                'settings': json.dumps(self.template_contexts()),
-                'disable_upload': attrs.get('disable_upload', summernote_config['disable_upload']),
+                'settings': json.dumps(contexts),
                 'lazy': attrs.get('lazy', summernote_config['lazy']),
                 'CSRF_COOKIE_NAME': settings.CSRF_COOKIE_NAME,
             }


### PR DESCRIPTION
Added ability to override any django-summernote and summernote default settings on a per widget basis.

Back story: I use summernote (through django-summernote) in a few places on my site. I wanted to disable uploads in all spots EXCEPT for one. That was easy enough, but I wasn't able to re-enable it on the one field I needed it on.

Fixes #278. Fixes #281.