### PR TITLE
fix widget repeat rendering

### DIFF
--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -50,7 +50,7 @@ class SummernoteWidgetBase(forms.Textarea):
 class SummernoteWidget(SummernoteWidgetBase):
     def render(self, name, value, attrs=None):
         summernote_settings = self.summernote_settings()
-        summernote_settings.update(self.attrs.pop('summernote', {}))
+        summernote_settings.update(self.attrs.get('summernote', {}))
 
         attrs_for_textarea = attrs.copy()
         attrs_for_textarea['hidden'] = 'true'
@@ -94,7 +94,7 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
 
     def render(self, name, value, attrs=None):
         summernote_settings = self.summernote_settings()
-        summernote_settings.update(self.attrs.pop('summernote', {}))
+        summernote_settings.update(self.attrs.get('summernote', {}))
 
         attrs_for_textarea = attrs.copy()
         attrs_for_textarea['hidden'] = 'true'


### PR DESCRIPTION
If pop is used to get the value of 'summernote' on self.attrs, then the html returned by render() may change after the first call.  For example:
```python
w=SummernoteWidget(attrs={'summernote':{'height':'123px'}})
w.render('test','',attrs={'id':'test'})
```
Will render the iframe height as '123px', however a second call 
```python
w.render('test','',attrs={'id':'test'})
```
will render whatever the default value for height is instead of '123px' because the summernote value of attrs was popped in the first call and therefore is no longer available for subsequent calls.

This PR fixes that by chaning the self.attrs.pop('summernote', {}) calls in both widgets to self.attrs.get('summernote', {})