### PR TITLE
Do not load language file if it's en-US locale

### DIFF
--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -29,13 +29,14 @@ class SummernoteWidgetBase(forms.Textarea):
         lang = _get_proper_language()
 
         summernote_settings = summernote_config.get('summernote', {}).copy()
-        summernote_settings.update({
-            'lang': lang,
-            'url': {
-                'language': static('summernote/lang/summernote-' + lang + '.min.js'),
-                'upload_attachment': reverse('django_summernote-upload_attachment'),
-            },
-        })
+        if lang != "en-US":
+             summernote_settings.update({
+                 'lang': lang,
+                 'url': {
+                     'language': static('summernote/lang/summernote-' + lang + '.min.js'),
+                     'upload_attachment': reverse('django_summernote-upload_attachment'),
+                 },
+             })
         return summernote_settings
 
     def value_from_datadict(self, data, files, name):


### PR DESCRIPTION
Otherwise it throws errors for when used with ManifestFiles option in django-s3-storage because there is no js file matching that name.