### PR TITLE
Fix compatibility django 2.1 method render

### DIFF
--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -48,7 +48,7 @@ class SummernoteWidgetBase(forms.Textarea):
 
 
 class SummernoteWidget(SummernoteWidgetBase):
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         summernote_settings = self.summernote_settings()
         summernote_settings.update(self.attrs.pop('summernote', {}))
 


### PR DESCRIPTION
Fix compatibility to Django 2.1 release:

> "Support for Widget.render ( ) methods without the renderer argument is removed."

Close #309