### PR TITLE
Lazily load the `attachment_upload_to` configuration setting

### DIFF
--- a/django_summernote/apps.py
+++ b/django_summernote/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 from django.conf import settings as django_settings
 from django_summernote.utils import (
-    LANG_TO_LOCALE, uploaded_filepath, get_theme_files
+    LANG_TO_LOCALE, get_theme_files
 )
 
 
@@ -29,7 +29,7 @@ class DjangoSummernoteConfig(AppConfig):
 
             # Attachment settings
             'disable_attachment': False,
-            'attachment_upload_to': uploaded_filepath,
+            'attachment_upload_to': 'django_summertime.utils.uploaded_filepath',
             'attachment_storage_class': None,
             'attachment_filesize_limit': 1024 * 1024,
             'attachment_require_authentication': False,

--- a/django_summernote/utils.py
+++ b/django_summernote/utils.py
@@ -114,6 +114,25 @@ SUMMERNOTE_THEME_FILES = {
 }
 
 
+def get_by_qname(path, desc):
+    try:
+        dot = path.rindex('.')
+    except ValueError:
+        raise ImproperlyConfigured("%s isn't a %s module." % (path, desc))
+    module, objname = path[:dot], path[dot + 1:]
+    try:
+        mod = import_module(module)
+    except ImportError as e:
+        raise ImproperlyConfigured('Error importing %s module %s: "%s"' %
+                (desc, module, e))
+    try:
+        obj = getattr(mod, objname)
+        return obj
+    except AttributeError:
+        raise ImproperlyConfigured('%s module "%s" does not define "%s"'
+                % (desc[0].upper() + desc[1:], module, objname))
+
+
 def using_config(_func=None):
     """
     This allows a function to use Summernote configuration
@@ -204,7 +223,7 @@ def get_attachment_upload_to():
     """
     Return 'attachment_upload_to' from configuration
     """
-    return config['attachment_upload_to']
+    return get_by_qname(config['attachment_upload_to'])
 
 
 @using_config

--- a/django_summernote/utils.py
+++ b/django_summernote/utils.py
@@ -223,7 +223,7 @@ def get_attachment_upload_to():
     """
     Return 'attachment_upload_to' from configuration
     """
-    return get_by_qname(config['attachment_upload_to'])
+    return get_by_qname(config['attachment_upload_to'], 'attachment_upload_to')
 
 
 @using_config


### PR DESCRIPTION
In our project structure we can't simply import a function into our settings file to use within the `SUMMERNOTE_CONFIG` - trying to import a function before the project has been initialised simply doesn't work. In our specific case we import settings from environment variables and use a multiple settings files per environment which complicates things further.

This PR changes the `attachment_upload_to` to accept the dot notation to the file to be used, which is then loaded when it's needed.

This is a breaking change so I could work some backwards compatibility in to this if it's something you'd like to use in master?