### PR TITLE
Lazily load the `attachment_upload_to` configuration setting

### DIFF
--- a/django_summernote/templates/django_summernote/widget_common.html
+++ b/django_summernote/templates/django_summernote/widget_common.html
@@ -71,12 +71,11 @@ function initSummernote_{{ id }}() {
                                 nDropdown.css("left", left + "px");
                             }
                         });
-
-                        $nCodable.blur(function() {
-                            origin.value = $nCodable.val();
-                        });
                     },
                     onBlur: function() {
+                        origin.value = $sn.summernote('code');
+                    },
+                    onBlurCodeview: function() {
                         origin.value = $sn.summernote('code');
                     },
                     {% if not config.disable_attachment %}
@@ -114,16 +113,6 @@ function initSummernote_{{ id }}() {
 
         // include summernote language pack, synchronously
         $.ajax({url: settings.url.language, dataType: "script", complete: initEditor})
-
-        // For CodeMirror
-        $sn.on('summernote.codeview.toggled', function() {
-            var cmEditor = $nCodable.data('cmEditor');
-            if( cmEditor ) {
-                cmEditor.on('blur', function() {
-                    origin.value = cmEditor.getValue();
-                });
-            }
-        });
 
 {% if not iframe %}
         // See https://docs.djangoproject.com/en/dev/ref/contrib/csrf/#ajax

--- a/django_summernote/views.py
+++ b/django_summernote/views.py
@@ -23,15 +23,15 @@ class SummernoteEditor(TemplateView):
 
         self.css = \
             config['base_css'] \
-            + config['css'] \
             + (config['codemirror_css'] if 'codemirror' in config else ()) \
-            + static_default_css
+            + static_default_css \
+            + config['css']
 
         self.js = \
             config['base_js'] \
-            + config['js'] \
             + (config['codemirror_js'] if 'codemirror' in config else ()) \
-            + static_default_js
+            + static_default_js \
+            + config['js']
 
     @using_config
     def get_context_data(self, **kwargs):

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -87,15 +87,15 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
         return forms.Media(
             css={
                 'all': (
-                    config['css_for_inplace'] +
                     (config['codemirror_css'] if 'codemirror' in config else ()) +
-                    config['default_css']
+                    config['default_css'] +
+                    config['css_for_inplace']
                 )
             },
             js=(
-                config['js_for_inplace'] +
                 (config['codemirror_js'] if 'codemirror' in config else ()) +
-                config['default_js']
+                config['default_js'] +
+                config['js_for_inplace']
             ))
 
     media = property(_media)
@@ -108,7 +108,6 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
         html = super(SummernoteInplaceWidget, self).render(
             name, value, attrs=attrs, **kwargs
         )
-        print(self.final_attr(attrs))
         context = {
             'id': attrs['id'].replace('-', '_'),
             'id_src': attrs['id'],

--- a/djs_playground/settings.py
+++ b/djs_playground/settings.py
@@ -130,6 +130,7 @@ SUMMERNOTE_CONFIG = {
             ['style', ['style']],
             ['font', ['bold', 'italic', 'clear', ]],
             ['color', ['forecolor', 'backcolor', ]],
+            ['misc', ['fullscreen', 'codeview', 'help', ]],
         ],
     },
     'css': (


### PR DESCRIPTION
In our project structure we can't simply import a function into our settings file to use within the `SUMMERNOTE_CONFIG` - trying to import a function before the project has been initialised simply doesn't work. In our specific case we import settings from environment variables and use a multiple settings files per environment which complicates things further.

This PR changes the `attachment_upload_to` to accept the dot notation to the file to be used, which is then loaded when it's needed.

This is a breaking change so I could work some backwards compatibility in to this if it's something you'd like to use in master?