### PR TITLE
HOTFIX - Fix ImportError in Django 1.9.x

### DIFF
--- a/django_summernote/views.py
+++ b/django_summernote/views.py
@@ -5,7 +5,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
 from django_summernote.utils import get_attachment_model, using_config
-if django_version <= (1, 9):
+if django_version < (1, 10):
     from django.views.generic import View
 else:
     from django.views import View


### PR DESCRIPTION
Change condition to import old or new Django View class.

Closes #340