### PR TITLE
css in SUMMERNOTE_CONFIG is not a dict, it's be a tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,9 @@ SUMMERNOTE_CONFIG = {
 
     # Codemirror as codeview
     # If any codemirror settings are defined, it will include codemirror files automatically.
-    'css': {
+    'css': (
         '//cdnjs.cloudflare.com/ajax/libs/codemirror/5.29.0/theme/monokai.min.css',
-    },
+    ),
     'codemirror': {
         'mode': 'htmlmixed',
         'lineNumbers': 'true',


### PR DESCRIPTION
If you copy the SUMMERNOTE_CONFIG in README.md to settings, and use summernote form
TypeError is occurred

here is the detail 
"
TypeError at /summernote/editor/id_content/
can only concatenate tuple (not "set") to tuple
"