### PR TITLE
Add attachment_absolute_uri

### DIFF
--- a/django_summernote/apps.py
+++ b/django_summernote/apps.py
@@ -34,6 +34,7 @@ class DjangoSummernoteConfig(AppConfig):
             'attachment_filesize_limit': 1024 * 1024,
             'attachment_require_authentication': False,
             'attachment_model': 'django_summernote.Attachment',
+            'attachment_absolute_uri': False,
 
             # Shortcut name for jQuery
             'jquery': '$',

--- a/django_summernote/templates/django_summernote/upload_attachment.json
+++ b/django_summernote/templates/django_summernote/upload_attachment.json
@@ -4,7 +4,7 @@
     {
         "name": "{{ attachment.name }}",
         "size": {{ attachment.file.size|unlocalize }},
-        "url": "{{ attachment.file.url|safe }}"
+        "url": "{{ attachment.url|safe }}"
     }
     {% if not forloop.last %},{% endif %}
 {% endfor %}

--- a/django_summernote/views.py
+++ b/django_summernote/views.py
@@ -88,7 +88,6 @@ class SummernoteUploadAttachment(View):
                 # create instance of appropriate attachment class
                 klass = get_attachment_model()
                 attachment = klass()
-
                 attachment.file = file
                 attachment.name = file.name
 
@@ -100,6 +99,13 @@ class SummernoteUploadAttachment(View):
 
                 # calling save method with attachment parameters as kwargs
                 attachment.save(**kwargs)
+
+                # choose relative/absolute url by config
+                attachment.url = attachment.file.url
+
+                if config['attachment_absolute_uri']:
+                    attachment.url = request.build_absolute_uri(attachment.url)
+
                 attachments.append(attachment)
 
             return HttpResponse(render_to_string('django_summernote/upload_attachment.json', {


### PR DESCRIPTION
By turning `attachment_absolute_uri` on, attachment paths will be returned in absolute URIs.

This fixes #351 