### PR TITLE
Replace deprecated django static import (fix #355)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: xenial
 language: python
 python:
   - "2.7"

--- a/django_summernote/views.py
+++ b/django_summernote/views.py
@@ -1,5 +1,5 @@
 from django import VERSION as django_version
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.http import HttpResponse, JsonResponse
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -1,7 +1,7 @@
 import json
 from django import forms
 from django.conf import settings as django_settings
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,10 @@ envlist =
 
 [travis]
 python =
-    2.7 = py27
-    3.4 = py34
-    3.5 = py35
-    3.6 = py36
+    2.7: py27
+    3.4: py34
+    3.5: py35
+    3.6: py36
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,12 @@ envlist =
     {py34,py35}-{dj108,dj111,dj200},
     {py36}-{dj111,dj200,dj201,djmaster}
 
-[tox:travis]
-2.7 = py27
-3.4 = py34
-3.5 = py35
-3.6 = py36
+[travis]
+python =
+    2.7 = py27
+    3.4 = py34
+    3.5 = py35
+    3.6 = py36
 
 [testenv]
 basepython =


### PR DESCRIPTION
`django.contrib.staticfiles.templatetags.static()` [is deprecated](https://docs.djangoproject.com/en/dev/releases/2.1/#features-deprecated-in-2-1) in favor of `django.templatetags.static.static()` so this PR reflects that state.


This should not affect older supported Django versions (like 1.8) because the logic was in place at that moment:
https://github.com/django/django/blob/1.8.19/django/contrib/staticfiles/templatetags/staticfiles.py
https://github.com/django/django/blob/1.8.19/django/templatetags/static.py