### PR TITLE
Python3 + Django 2.x support

### DIFF
--- a/django_summernote/models.py
+++ b/django_summernote/models.py
@@ -14,8 +14,8 @@ class AbstractAttachment(models.Model):
     )
     uploaded = models.DateTimeField(auto_now_add=True)
 
-    def __unicode__(self):
-        return u"%s" % (self.name)
+    def __str__(self):
+        return self.name
 
     class Meta:
         abstract = True


### PR DESCRIPTION
Removes "Attachment object (1)" error on listings 
![image](https://user-images.githubusercontent.com/264640/59555055-312c8600-8f83-11e9-9966-eaf303fa4d20.png)
