### PR TITLE
Fix logic to check the existence of codemirror config

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ SUMMERNOTE_CONFIG = {
         'print': {
             'stylesheetUrl': '/some_static_folder/printable.css',
         },
+        'codemirror': {
+            'mode': 'htmlmixed',
+            'lineNumbers': 'true',
+            # You have to include theme file in 'css' or 'css_for_inplace' before using it.
+            'theme': 'monokai',
+        },
     },
 
     # Need authentication while uploading attachments.
@@ -225,13 +231,6 @@ SUMMERNOTE_CONFIG = {
     'css': (
         '//cdnjs.cloudflare.com/ajax/libs/codemirror/5.29.0/theme/monokai.min.css',
     ),
-    'codemirror': {
-        'mode': 'htmlmixed',
-        'lineNumbers': 'true',
-
-        # You have to include theme file in 'css' or 'css_for_inplace' before using it.
-        'theme': 'monokai',
-    },
 
     # Lazy initialize
     # If you want to initialize summernote at the bottom of page, set this as True

--- a/django_summernote/utils.py
+++ b/django_summernote/utils.py
@@ -247,3 +247,8 @@ def get_attachment_storage():
         return storage_class()
     else:
         return default_storage
+
+@using_config
+def has_codemirror_config():
+    return 'summernote' in config and \
+        'codemirror' in config['summernote']

--- a/django_summernote/views.py
+++ b/django_summernote/views.py
@@ -8,7 +8,8 @@ from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
 
 from django_summernote.forms import UploadForm
-from django_summernote.utils import get_attachment_model, using_config
+from django_summernote.utils import get_attachment_model, using_config, \
+    has_codemirror_config
 
 logger = logging.getLogger(__name__)
 
@@ -28,16 +29,15 @@ class SummernoteEditor(TemplateView):
 
         static_default_css = tuple(static(x) for x in config['default_css'])
         static_default_js = tuple(static(x) for x in config['default_js'])
-
         self.css = \
             config['base_css'] \
-            + (config['codemirror_css'] if 'codemirror' in config else ()) \
+            + (config['codemirror_css'] if has_codemirror_config() else ()) \
             + static_default_css \
             + config['css']
 
         self.js = \
             config['base_js'] \
-            + (config['codemirror_js'] if 'codemirror' in config else ()) \
+            + (config['codemirror_js'] if has_codemirror_config() else ()) \
             + static_default_js \
             + config['js']
 

--- a/django_summernote/widgets.py
+++ b/django_summernote/widgets.py
@@ -5,7 +5,8 @@ from django.templatetags.static import static
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
-from django_summernote.utils import get_proper_language, using_config
+from django_summernote.utils import get_proper_language, using_config, \
+    has_codemirror_config
 
 try:
     from django.urls import reverse  # Django >= 2.0
@@ -88,13 +89,13 @@ class SummernoteInplaceWidget(SummernoteWidgetBase):
         return forms.Media(
             css={
                 'all': (
-                        (config['codemirror_css'] if 'codemirror' in config else ()) +
+                        (config['codemirror_css'] if has_codemirror_config() else ()) +
                         config['default_css'] +
                         config['css_for_inplace']
                 )
             },
             js=(
-                    (config['codemirror_js'] if 'codemirror' in config else ()) +
+                    (config['codemirror_js'] if has_codemirror_config() else ()) +
                     config['default_js'] +
                     config['js_for_inplace']
             ))

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ CLASSIFIERS = [
     'Topic :: Utilities',
 ]
 
+TESTS_REQUIRE = ['django-dummy-plug']
 # mock is available as unittest.mock in Python 3.3 onwards.
-TESTS_REQUIRE = ['django-dummy-plug'] + \
-    ['mock'] if sys.version_info < (3, 3, 0) else []
-    
+if sys.version_info < (3, 3, 0):
+    TESTS_REQUIRE += ['mock']
 
 setup(
     name=PROJECT,

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 from setuptools import setup, find_packages
 from django_summernote import version, PROJECT
 
@@ -24,6 +25,9 @@ CLASSIFIERS = [
     'Topic :: Utilities',
 ]
 
+# mock is available as unittest.mock in Python 3.3 onwards.
+TESTS_REQUIRE = ['mock'] if sys.version_info < (3, 3, 0) else [] \
+    + ['django-dummy-plug']
 
 setup(
     name=PROJECT,
@@ -41,5 +45,5 @@ setup(
 
     install_requires=['django'],
     test_suite='runtests.runtests',
-    tests_require=['django-dummy-plug', 'mock'],
+    tests_require=TESTS_REQUIRE,
 )

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,9 @@ CLASSIFIERS = [
 ]
 
 # mock is available as unittest.mock in Python 3.3 onwards.
-TESTS_REQUIRE = ['mock'] if sys.version_info < (3, 3, 0) else [] \
-    + ['django-dummy-plug']
+TESTS_REQUIRE = ['django-dummy-plug'] + \
+    ['mock'] if sys.version_info < (3, 3, 0) else []
+    
 
 setup(
     name=PROJECT,


### PR DESCRIPTION
This commit fixes https://github.com/summernote/django-summernote/issues/344

In README.md, the `codemirror` related settings were at the top of config.
For now, we should pass the `codemirror` settings to `summernote library(js)` together with `config ['summernote']`.

### Changes

- Find key `codemirror` in `config ['summernote']`, not config.
- Updated the out-dated README.md to match the current implementation.
- Also, i modified `setup.py` to install only on Python versions lower than 3.3 when testing.
