### PR TITLE
docs: Fix simple typo, backword -> backward

### DIFF
--- a/django_summernote/apps.py
+++ b/django_summernote/apps.py
@@ -97,7 +97,7 @@ class DjangoSummernoteConfig(AppConfig):
     def _copy_old_configs(self, user, default):
         """
         NOTE: Will be deprecated from 0.9
-        Copying old-style settings for backword-compatibility
+        Copying old-style settings for backward-compatibility
         """
         DEPRECATED_SUMMERNOTE_CONFIGS = (
             'width',


### PR DESCRIPTION
There is a small typo in django_summernote/apps.py.

Should read `backward` rather than `backword`.

