### PR TITLE
Set X-Frame-Options setting on a per-view basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,7 @@ SETUP
 
      - Please, read the [official v3.0 documentation](https://docs.djangoproject.com/en/3.0/topics/files/) for more details on file uploads.
 
-5. If you're using Django 3.x with default SummernoteWidget, then
-
-     - Do not forget to set `X_FRAME_OPTIONS = 'SAMEORIGIN'` in your django settings.
-     - [Clickjacking Protection](https://docs.djangoproject.com/en/3.0/ref/clickjacking/)
-
-6. Run database migration for preparing attachment model.
+5. Run database migration for preparing attachment model.
 
        python manage.py migrate
 
@@ -194,7 +189,7 @@ SUMMERNOTE_CONFIG = {
 
         # Use proper language setting automatically (default)
         'lang': None,
-        
+
         # Toolbar customization
         # https://summernote.org/deep-dive/#custom-toolbar-popover
         'toolbar': [

--- a/django_summernote/views.py
+++ b/django_summernote/views.py
@@ -9,6 +9,8 @@ if django_version >= (3, 0):
 else:
     from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
+from django.utils.decorators import method_decorator
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 
 from django_summernote.forms import UploadForm
 from django_summernote.utils import get_attachment_model, using_config, \
@@ -44,6 +46,10 @@ class SummernoteEditor(TemplateView):
             + static_default_js \
             + config['js']
 
+    @method_decorator(xframe_options_sameorigin)
+    def dispatch(self, *args, **kwargs):
+        return super(SummernoteEditor, self).dispatch(*args, **kwargs)
+
     @using_config
     def get_context_data(self, **kwargs):
         context = super(SummernoteEditor, self).get_context_data(**kwargs)
@@ -64,6 +70,10 @@ class SummernoteUploadAttachment(UserPassesTestMixin, View):
 
     def __init__(self):
         super(SummernoteUploadAttachment, self).__init__()
+
+    @method_decorator(xframe_options_sameorigin)
+    def dispatch(self, *args, **kwargs):
+        return super(SummernoteUploadAttachment, self).dispatch(*args, **kwargs)
 
     def get(self, request, *args, **kwargs):
         return JsonResponse({


### PR DESCRIPTION
Hello, I was wondering what you would think of setting X-Frame-Options on a per-view basis, rather than having users specify `X_FRAME_OPTIONS` for the entire site in the settings file? This would allow the site still to run with the default `X-Frame-Options: DENY` for general security, while letting the Summernote frames through.

I notice this has been suggested by @mimi89999 in https://github.com/summernote/django-summernote/issues/381#issuecomment-565726657, but I wasn't sure what the outcome of that was.

In our project we only use the text editors (we don't use file attachments), so I might not have caught every relevant spot—let me know if I missed something.

Thanks for your work on this package, it's been a godsend for us!