### PR TITLE
Fix the README.md to use the right field class

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ And for `ModelForm`,
 
 ```python
 class FormForSomeModel(forms.ModelForm):
-    foo = SummernoteFormField()
+    foo = SummernoteTextField()
 ```
 
 THEMES


### PR DESCRIPTION
Fixing the form usage documentation to refer to the right field class: SummernoteTextField.