### PR TITLE
Change url in favor of the re_path

### DIFF
--- a/djs_playground/urls.py
+++ b/djs_playground/urls.py
@@ -1,11 +1,11 @@
 from django.conf import settings
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from django.conf.urls.static import static
 from django.contrib import admin
 from djs_playground.views import index
 
 urlpatterns = [
-    url(r'^$', index, name='index'),
-    url(r'^admin/', admin.site.urls),
-    url(r'^summernote/', include('django_summernote.urls')),
+    re_path(r'^$', index, name='index'),
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^summernote/', include('django_summernote.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Changing the URL deprecated method for the re_path method.

#441 