### PR TITLE
Update Django's main branch name in tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {py36,py37}-{dj202,dj300,dj301,dj302}
-    {py38,py39}-{dj202,dj300,dj301,dj302,djmaster}
+    {py38,py39}-{dj202,dj300,dj301,dj302,djmain}
 
 [travis]
 python =
@@ -27,6 +27,6 @@ deps =
     dj300: Django<3.1
     dj301: Django<3.2
     dj302: Django<3.3
-    djmaster: https://github.com/django/django/archive/master.tar.gz
+    djmain: https://github.com/django/django/archive/main.tar.gz
 
 commands = coverage run -m pytest


### PR DESCRIPTION
Django main branch's name is changed to "main" from "master". Tox should be updated in order to be able to run tests with  latest Django.

https://twitter.com/m_holtermann/status/1369209521101545472