### PR TITLE
Adds a config for different authentication methods for uploading attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,17 @@ SUMMERNOTE_CONFIG = {
     # Require users to be authenticated for uploading attachments.
     'attachment_require_authentication': True,
 
+    # Set an authentication fuction for uploading attachments (default: None)
+    # - default authentication method is `request.user.is_authenticated`
+    # - custom authentication function must have an argument for HttpRequest
+    #   ```
+    #   from django.http import HttpRequest
+    #
+    #   def example_auth_func(request: HttpRequest):
+    #       return request.user.has_perm('can_upload')
+    #   ```
+    'attachment_authentication_func': None
+
     # Set `upload_to` function for attachments.
     'attachment_upload_to': my_custom_upload_to_func(),
 

--- a/django_summernote/apps.py
+++ b/django_summernote/apps.py
@@ -33,6 +33,7 @@ class DjangoSummernoteConfig(AppConfig):
             'attachment_storage_class': None,
             'attachment_filesize_limit': 1024 * 1024,
             'attachment_require_authentication': False,
+            'attachment_authentication_func': None,
             'attachment_model': 'django_summernote.Attachment',
             'attachment_absolute_uri': False,
 

--- a/django_summernote/test_django_summernote.py
+++ b/django_summernote/test_django_summernote.py
@@ -319,6 +319,24 @@ class DjangoSummernoteTest(TestCase):
             response = self.client.post(url, {'files': [fp]})
             self.assertEqual(response.status_code, 200)
 
+    def test_attachment_authentication_func_is_set(self):
+        url = reverse('django_summernote-upload_attachment')
+        self.summernote_config['attachment_require_authentication'] = True
+        def auth_func(request):
+            return True
+        self.summernote_config['attachment_authentication_func'] = auth_func
+        with open(IMAGE_FILE, 'rb') as fp:
+            response = self.client.post(url, {'files': [fp]})
+            self.assertEqual(response.status_code, 200)
+
+    def test_attachment_authentication_func_is_not_set(self):
+        url = reverse('django_summernote-upload_attachment')
+        self.summernote_config['attachment_require_authentication'] = True
+        self.summernote_config['attachment_authentication_func'] = None
+        with open(IMAGE_FILE, 'rb') as fp:
+            response = self.client.post(url, {'files': [fp]})
+            self.assertEqual(response.status_code, 403)
+
     @override_settings(USE_THOUSAND_SEPARATOR=True)
     def test_attachment_with_thousand_separator_option(self):
         url = reverse('django_summernote-upload_attachment')

--- a/django_summernote/views.py
+++ b/django_summernote/views.py
@@ -74,6 +74,8 @@ class SummernoteUploadAttachment(UserPassesTestMixin, View):
 
     def post(self, request, *args, **kwargs):
         authenticated = request.user.is_authenticated
+        if get_config()['attachment_authentication_func']:
+            authenticated = get_config()['attachment_authentication_func'](self.request)
 
         if self.config['disable_attachment']:
             logger.error(


### PR DESCRIPTION
for checking permissions different with `request.user.is_authenticated` 
```
# Set an authentication fuction for uploading attachments (default: None)
# - default authentication method is `request.user.is_authenticated`
# - custom authentication function must have an argument for HttpRequest
#   ```
#   from django.http import HttpRequest
#
#   def example_auth_func(request: HttpRequest):
#       return request.user.has_perm('can_upload')
#   ```
```