### PR TITLE
set default_auto_field to silence django 3.2 warnings

### DIFF
--- a/django_summernote/apps.py
+++ b/django_summernote/apps.py
@@ -8,6 +8,7 @@ from django_summernote.utils import (
 class DjangoSummernoteConfig(AppConfig):
     name = 'django_summernote'
     verbose_name = 'Django Summernote'
+    default_auto_field = 'django.db.models.AutoField'
 
     theme = 'bs3'
     config = {}


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys