### PR TITLE
docs: fix simple typo, attachement -> attachment

### DIFF
--- a/django_summernote/test_django_summernote.py
+++ b/django_summernote/test_django_summernote.py
@@ -303,7 +303,7 @@ class DjangoSummernoteTest(TestCase):
                 )
                 self.assertTrue(mock_logging.error.called)
         except ImportError:
-            # Without PIL, we cannot check the uploaded attachement has image format or not
+            # Without PIL, we cannot check the uploaded attachment has image format or not
             with open(IMAGE_FILE, 'rb') as fp:
                 response = self.client.post(url, {'files': [fp]})
                 self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
There is a small typo in django_summernote/test_django_summernote.py.

Should read `attachment` rather than `attachement`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md