### PR TITLE
Explicitly specify 'id' field in attachment model

### DIFF
--- a/django_summernote/models.py
+++ b/django_summernote/models.py
@@ -1,11 +1,12 @@
 from django.db import models
-from django_summernote.utils import get_attachment_storage, get_attachment_upload_to
 
+from django_summernote.utils import get_attachment_storage, get_attachment_upload_to
 
 __all__ = ['AbstractAttachment', 'Attachment', ]
 
 
 class AbstractAttachment(models.Model):
+    id = models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
     name = models.CharField(max_length=255, null=True, blank=True, help_text="Defaults to filename, if left blank")
     file = models.FileField(
         upload_to=get_attachment_upload_to(),


### PR DESCRIPTION
This resolves a downstream issue where projects using "BigAutoField" as their default auto field, will generate an unwanted migration.

 The unwanted migration will switch the field from AutoField to BigAutoField. This is unnecessary and causes issues - especially when working in an environment where you don't have permission to create the migration (e.g. #492).