### PR TITLE
To solve this problem I removed (styles=STYLES) from the fields.py file #513

### DIFF
--- a/django_summernote/fields.py
+++ b/django_summernote/fields.py
@@ -16,7 +16,7 @@ class SummernoteTextFormField(fields.CharField):
     def to_python(self, value):
         value = super().to_python(value)
         return bleach.clean(
-            value, tags=ALLOWED_TAGS, attributes=ATTRIBUTES, styles=STYLES)
+            value, tags=ALLOWED_TAGS, attributes=ATTRIBUTES)
 
 
 class SummernoteTextField(models.TextField):
@@ -27,4 +27,4 @@ class SummernoteTextField(models.TextField):
     def to_python(self, value):
         value = super().to_python(value)
         return bleach.clean(
-            value, tags=ALLOWED_TAGS, attributes=ATTRIBUTES, styles=STYLES)
+            value, tags=ALLOWED_TAGS, attributes=ATTRIBUTES)


### PR DESCRIPTION
Aplicado ao #513
Ao aplicar a summernote, em apenas um ele informa um erro 'typeError at/'.

```clean() got na unexpected keyword argument 'style'```

para resolver este problemas removi a (styles=STYLES), do arquivo fields.py 

of classes:
```
class SummernoteTextField(models.TextField):
class SummernoteTextFormField(fields.CharField):
```

![erro_django](https://github.com/user-attachments/assets/1f31e754-f0c5-4f7c-a0b9-a3b43a8e2ec4)
